### PR TITLE
지진감지

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "firebase-token-generator": "^2.0.0",
     "coffee-script": "^1.10.0",
     "moment": "^2.13.0",
-    "q": "^1.4.1"
+    "q": "^1.4.1",
+    "request" : "2.75.0"
   },
   "peerDependencies": {
     "hubot": "2.x"

--- a/scripts/earthQuake.coffee
+++ b/scripts/earthQuake.coffee
@@ -1,0 +1,19 @@
+request = require('request');
+module.exports = (robot) ->
+  url = 'https://twitter.com/search?f=tweets&vertical=default&q=%EC%A7%80%EC%A7%84'
+  setInterval (->
+    request url, (error, response, html) ->
+      if !error
+        regex = /(data-aria-label-part="last">([1]|)[0-9]초 전)/g
+        count = 0
+        loop
+          arr = regex.exec(html)
+          if arr != null
+            count++
+          else
+            break
+        if count == 20
+          robot.messageRoom '#_general', '지진!!!!!!!!!!'
+      return
+    return
+  ), 60000

--- a/scripts/earthQuake.coffee
+++ b/scripts/earthQuake.coffee
@@ -12,7 +12,7 @@ module.exports = (robot) ->
             count++
           else
             break
-        if count == 20
+        if count >= 20
           robot.messageRoom '#_general', '지진!!!!!!!!!!'
       return
     return


### PR DESCRIPTION
텔레그램에 `지진희알림`이 있길래 비슷하게 하나 만들었습니다!

1분마다 트위터에 `지진`단어를 가지고 검색 0~19초 사이에 지진 관련 트윗이 20개 이상일 경우 (검색은 딱 20개를 가지고 하지만 혹시 모르니..) general 방에 메세지가 가도록 했습니다. 확인해보시구 수정하시거나 (거절하시거나..) 받아주세요~
