### PR TITLE
Response to "Registered OSS title"

### DIFF
--- a/scripts/scheduler.coffee
+++ b/scripts/scheduler.coffee
@@ -98,3 +98,15 @@ module.exports = (robot) ->
 
   getUserName = (msg) ->
     msg.message.user.name.replace /\./g, "_"
+
+  # 등록 된 오픈소스의 타이틀 감지
+  robot.hear /.*/, (msg) ->
+    fb.child('cm_오픈소스').once "value", (data) ->
+      if data.val()?
+        data.forEach (data) ->
+          memo = data.val()
+          try
+            title = (/\[(.+?)\]/).exec(memo)[1]
+            matched = new RegExp(title, 'gi').test msg.message.text
+            if matched is true?
+              msg.send memo


### PR DESCRIPTION
메모로 등록 된 오픈소스의 타이틀을 말하면 자동으로 해당 메모를 출력합니다.
```
9xd> use Nagato!
*[Nagato]* : https://github.com/kjwon15/nagato
```

regex가 현재 `.*`로 되어있는데 오픈소스! <제목> 등으로 바꾸는 게 나을까요?