### PR TITLE
add cloud radar bot

### DIFF
--- a/scripts/cloudrader.coffee
+++ b/scripts/cloudrader.coffee
@@ -1,0 +1,26 @@
+# Description
+#   현재 기상 레이더 사진을 10분단위로 가져와서 비가올지 직접 판단할 수 있도록 하자.
+#   구름이나 미세한 물방울에 반사 및 산란해서 돌아온 전파를 수신하여 구름의 상태를 관측하는 레이다 장비이다.
+#   전파의 산란은 물방울이나 얼음 입자의 크기와 양, 형태에 따라 좌우되며,
+#   산란의 강도는 단위 부피속에 포함된 수적 입자의 양과 크기에 대해 정비례의 관계가 있으므로
+#   수신된 신호 강도로 강우의 강도를 추정할 수가 있다.
+#
+# Commands:
+#   일기에보를 믿을 수 없다면, 실시간으로 직접 보자.
+#
+# Author :
+#   dot2line
+
+module.exports = (robot) ->
+  robot.hear /구름아어딨니$/i, (msg) ->
+    today = new Date
+    today.setMinutes(today.getMinutes() - 20)
+
+    if today.getMinutes() % 10 != 0
+      minute = "#{today.getMinutes() - today.getMinutes() % 10}"
+    else
+      minute = "0#{today.getMinutes()}"
+
+    timeStr = "#{today.getFullYear()}#{today.getMonth() + 1}#{today.getDate()}#{today.getHours()}#{minute}"
+
+    msg.send "비구름은 여깄당! http://m.kma.go.kr/repositary/image/rdr/img/RDR_TOQCZ_CP15M1_" + "#{timeStr}.png"


### PR DESCRIPTION
### motivation
일기예보가 몇시 기준으로 정보를 받는지 애매하고
우리는 지금 비가 오는지 우산을 챙겨야하는지 `비` `구름` `맑음` 이 세단어로 확실히 구분하기에는 너무 힘들다.
멀리서 오는 구름을 체크할 수도 있으면 좋을 것 같기도하고 실제로 레이더 사진을 보고 싶기도 해서 만들었다.

### description
`구름아어딨니` 하면
현재 기상 레이더 사진을 10분 단위로 가져올 수 있다.

### example
http://m.kma.go.kr/repositary/image/rdr/img/RDR_TOQCZ_CP15M1_201711171130.png

### To owner
제가 자바스크립트도 잘 못쓰는 모바일 개발자라서 코드는 ~~거지같진~~ 깔끔하진 않지만 잘은 돌아갈 겁니다.